### PR TITLE
Refresh personal site copy and metadata

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -14,10 +14,10 @@ export const metadata: Metadata = {
     default: 'Nico Albanese',
     template: '%s | Nico Albanese',
   },
-  description: 'Working on the AI SDK at Vercel',
+  description: 'Member of Technical Staff at OpenAI, working on the Codex app',
   openGraph: {
     title: 'Nico Albanese',
-    description: 'Working on the AI SDK at Vercel',
+    description: 'Member of Technical Staff at OpenAI, working on the Codex app',
     url: baseUrl,
     siteName: 'Nico Albanese',
     locale: 'en_US',

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,11 +10,15 @@ export default function Page() {
         Nico Albanese
       </h1>
       <p className="dark:text-neutral-100 text-neutral-900">
-        Currently working on the{" "}
+        Member of Technical Staff at{" "}
+        <ExternalLink href="https://openai.com">OpenAI</ExternalLink>, working on
+        the <ExternalLink href="https://openai.com/codex">Codex</ExternalLink> app.
+        Previously helped build and scale the{" "}
         <ExternalLink href="https://sdk.vercel.ai">AI SDK</ExternalLink> at{" "}
-        <ExternalLink href="https://vercel.com">Vercel</ExternalLink>. Created{" "}
-        <ExternalLink href="https://kirimase.dev">Kirimase</ExternalLink>, the
-        fastest way to start{" "}
+        <ExternalLink href="https://vercel.com">Vercel</ExternalLink> from 50k
+        to 15 million weekly downloads. Created{" "}
+        <ExternalLink href="https://kirimase.dev">Kirimase</ExternalLink>{" "}
+        (acquired by Vercel), the fastest way to start{" "}
         <ExternalLink href="https://nextjs.org">Next.js</ExternalLink>{" "}
         applications. Previously investing in pre-seed startups at{" "}
         <ExternalLink href="https://ascension.vc">Ascension</ExternalLink>.

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -14,7 +14,7 @@ export default function Page() {
         <ExternalLink href="https://openai.com">OpenAI</ExternalLink>, working on
         the <ExternalLink href="https://openai.com/codex">Codex</ExternalLink> app.
         Previously helped build and scale the{" "}
-        <ExternalLink href="https://sdk.vercel.ai">AI SDK</ExternalLink> at{" "}
+        <ExternalLink href="https://ai-sdk.dev">AI SDK</ExternalLink> at{" "}
         <ExternalLink href="https://vercel.com">Vercel</ExternalLink> from 50k
         to 15 million weekly downloads. Created{" "}
         <ExternalLink href="https://kirimase.dev">Kirimase</ExternalLink>{" "}

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -1,5 +1,4 @@
 import { Projects } from "app/components/projects";
-import { ExternalLink } from "../components/external-link";
 
 export default function Page() {
   return (
@@ -7,9 +6,8 @@ export default function Page() {
       <h1 className="mb-8 text-2xl font-semibold tracking-tighter">Projects</h1>
       <p className="mb-4">
         I love building things that can help make life better in any way. I also
-        love building things to learn how to use something new. I&apos;m lucky
-        to spend my days thinking of cool things to build with the <ExternalLink href="https://sdk.vercel.ai">AI SDK</ExternalLink>. Here
-        are a few projects I&apos;ve built or worked on.
+        love building things to learn how to use something new. Here are a few
+        projects I&apos;ve built or worked on.
       </p>
       <div className="my-8">
         <Projects />


### PR DESCRIPTION
## Summary
- Update homepage and metadata to reflect current role at OpenAI and work on the Codex app
- Add more specific context about prior Vercel work and Kirimase
- Simplify the Projects intro copy by removing the AI SDK reference

## Testing
- Not run (not requested)